### PR TITLE
fix:修复导入excel时表头与结构体字段不一致导致的数据错乱问题

### DIFF
--- a/excel.go
+++ b/excel.go
@@ -3,14 +3,15 @@ package structexcel
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/xuri/excelize/v2"
 	"io"
 	"net/http"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/xuri/excelize/v2"
 )
 
 type ExcelRemarks interface {
@@ -249,7 +250,6 @@ func (s *Sheet) expandHeader(dataValue reflect.Value, index int, col int) int {
 			}
 		}
 		if field.Kind() == reflect.Slice {
-
 		}
 	}
 	sort.Strings(keyList)
@@ -273,7 +273,7 @@ func (s *Sheet) expandHeader(dataValue reflect.Value, index int, col int) int {
 // transferHeaders
 // 展开表头
 func (s *Sheet) transferHeaders(data reflect.Value) *Sheet {
-	//var data reflect.Type
+	// var data reflect.Type
 	col := 1
 	var value reflect.Value
 	if data.Kind() == reflect.Slice {
@@ -475,7 +475,7 @@ func (s *Sheet) AddData(data interface{}) error {
 					}
 				}
 			}
-		//case reflect.Slice:
+		// case reflect.Slice:
 		//	for i := 0; i < valueStruct.Len(); i++ {
 		//		field := valueStruct.Index(i)
 		//		_ = s.addCol().setCellValue(field)
@@ -496,6 +496,7 @@ func (s *Sheet) readHeader(header []string) {
 		cell = strings.TrimSpace(cell)
 		if h, ok := headerMap[cell]; ok {
 			h.Col = col + 1
+			h.isMatch = true
 		} else {
 			for _, v := range expandHeader {
 				if v.expandRegex.MatchString(cell) {
@@ -509,6 +510,7 @@ func (s *Sheet) readHeader(header []string) {
 						expandRegex: nil,
 						skip:        false,
 						level:       2,
+						isMatch:     true,
 					})
 				}
 			}

--- a/excel_tag.go
+++ b/excel_tag.go
@@ -2,10 +2,11 @@ package structexcel
 
 import (
 	"fmt"
-	"github.com/xuri/excelize/v2"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/xuri/excelize/v2"
 )
 
 type excelHeaderField struct {
@@ -20,6 +21,7 @@ type excelHeaderField struct {
 	level       int
 	split       string
 	font        *excelize.Font
+	isMatch     bool
 }
 
 type excelHeaderNode struct {
@@ -166,7 +168,9 @@ func (x excelHeaderSlice) getExpandHeaderSlice() excelHeaderSlice {
 func (x excelHeaderSlice) getColHeaderMap() map[int]*excelHeaderField {
 	res := make(map[int]*excelHeaderField)
 	for _, v := range x {
-		res[v.Col] = v
+		if v.isMatch {
+			res[v.Col] = v
+		}
 	}
 	return res
 }


### PR DESCRIPTION
当导入的excel缺失某些列的时候，会导致依据数据结构体生成header struct中的Col字段出现重复，进而导致匹配excel的列出现混乱，通过标记结构体与excel文件的表头匹配情况修复此问题